### PR TITLE
add "tee" function

### DIFF
--- a/src/rresult.ml
+++ b/src/rresult.ml
@@ -28,13 +28,16 @@ module R = struct
   (* Composing results *)
 
   let bind v f = match v with Ok v -> f v | Error _ as e -> e
+  let tee v f = match v with Ok w -> begin match f w with Ok _ -> v | Error _ as e -> e end | Error _ as e -> e
   let map f v = match v with Ok v -> Ok (f v) | Error _ as e -> e
   let join r = match r with Ok v -> v | Error _ as e -> e
   let ( >>= ) = bind
+  let ( >>@ ) = tee
   let ( >>| ) v f = match v with Ok v -> Ok (f v) | Error _ as e -> e
 
   module Infix = struct
     let ( >>= ) = ( >>= )
+    let ( >>@ ) = ( >>@ )
     let ( >>| ) = ( >>| )
   end
 

--- a/src/rresult.mli
+++ b/src/rresult.mli
@@ -70,6 +70,9 @@ module R : sig
   val bind : ('a, 'b) result -> ('a -> ('c, 'b) result) -> ('c, 'b) result
   (** [bind r f] is [f v] if [r = Ok v] and [r] if [r = Error _]. *)
 
+  val tee : ('a, 'b) result -> ('a -> (_, 'b) result) -> ('a, 'b) result
+  (** [tee r f] is [f v] if [r = Ok v] and [f v = Error _]; otherwise it is r. *)
+
   val map : ('a -> 'c) -> ('a, 'b) result -> ('c, 'b) result
   (** [map f r] is [bind (fun v -> ret (f v))] r. *)
 
@@ -78,6 +81,9 @@ module R : sig
 
   val ( >>= ) : ('a, 'b) result -> ('a -> ('c, 'b) result) -> ('c, 'b) result
   (** [r >>= f] is {!bind}[ r f]. *)
+
+  val ( >>@ ) : ('a, 'b) result -> ('a -> (_, 'b) result) -> ('a, 'b) result
+  (** [r >>@ f] is {!tee}[ r f]. *)
 
   val ( >>| ) : ('a, 'b) result -> ('a -> 'c) -> ('c, 'b) result
   (** [r >>| f] is {!map}[ r f]. *)
@@ -91,6 +97,9 @@ module R : sig
 
     val ( >>= ) : ('a, 'b) result -> ('a -> ('c, 'b) result) -> ('c, 'b) result
     (** [(>>=)] is {!R.( >>= )}. *)
+
+    val ( >>@ ) : ('a, 'b) result -> ('a -> (_, 'b) result) -> ('a, 'b) result
+    (** [r >>@ f] is {!R.( >>@ )}. *)
 
     val ( >>| ) : ('a, 'b) result -> ('a -> 'c) -> ('c, 'b) result
     (** [(>>|)] is {!R.( >>| )}. *)


### PR DESCRIPTION
The `tee` function works like `tee(1)` by duplicating the input value and giving it to two outputs:
Very similar to `bind`, but if all goes well, the initial `Ok v` will be returned.
This is very handy to pipeline functions that only consume a value, that you want to use for the next pipelined function. Logging functions would be the prime example; I use it for network and database functions.

``` ocaml
let r = producer () >>@ consumer1 >>@ consumer2 >>= consumer3 in
...
```

I don't care much for the exact name, nor the exact infix operator.
